### PR TITLE
28/bug/renovate poetry lockfile

### DIFF
--- a/.github/actions/setup-ci-environment/action.yml
+++ b/.github/actions/setup-ci-environment/action.yml
@@ -44,7 +44,7 @@ runs:
           # Floating poetry version can trigger "lockfile too old". As a workaround (since Poetry
           # versions locally in CI can always differ), we run `poetry lock` to regenerate it.
           run: |-
-            rm poetry.lock
+            rm -f poetry.lock
             poetry lock
             poetry install --no-interaction --no-root --with dev
           shell: bash

--- a/.github/actions/setup-ci-environment/action.yml
+++ b/.github/actions/setup-ci-environment/action.yml
@@ -41,5 +41,10 @@ runs:
 
         - name: "Install Python dependencies"
           if: ${{ inputs.setup-python == 'true' }}
-          run: poetry install --no-interaction --no-root --with dev
+          # Floating poetry version can trigger "lockfile too old". As a workaround (since Poetry
+          # versions locally in CI can always differ), we run `poetry lock` to regenerate it.
+          run: |-
+            rm poetry.lock
+            poetry lock
+            poetry install --no-interaction --no-root --with dev
           shell: bash

--- a/.github/workflows/renovate-major.yml
+++ b/.github/workflows/renovate-major.yml
@@ -32,8 +32,3 @@ jobs:
                   RENOVATE_GIT_AUTHOR: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
                   RENOVATE_PACKAGE_RULES: '[{"matchUpdateTypes":["digest","minor","patch","pin","pinDigest","lockFileMaintenance"],"enabled":false}]'
                   RENOVATE_REPOSITORIES: ${{ github.repository }}
-
-                  # 2026-04-12: Workaround for Poetry lock file not updated reliably. Inside the Renovate
-                  # config, a post-upgrade task is used to manually delete and regenerate the lock file.
-                  # Otherwise, tests during the PR checks might fail.
-                  RENOVATE_ALLOWED_COMMANDS: '["echo [[Recreate Poetry lock file]]", "rm -f poetry.lock", "poetry lock"]'

--- a/.github/workflows/renovate-major.yml
+++ b/.github/workflows/renovate-major.yml
@@ -36,4 +36,4 @@ jobs:
                   # 2026-04-12: Workaround for Poetry lock file not updated reliably. Inside the Renovate
                   # config, a post-upgrade task is used to manually delete and regenerate the lock file.
                   # Otherwise, tests during the PR checks might fail.
-                  RENOVATE_ALLOWED_COMMANDS: '["echo [[Recreate Poetry lock file]]", "rm poetry.lock", "poetry lock"]'
+                  RENOVATE_ALLOWED_COMMANDS: '["echo [[Recreate Poetry lock file]]", "rm -f poetry.lock", "poetry lock"]'

--- a/.github/workflows/renovate-major.yml
+++ b/.github/workflows/renovate-major.yml
@@ -36,4 +36,4 @@ jobs:
                   # 2026-04-12: Workaround for Poetry lock file not updated reliably. Inside the Renovate
                   # config, a post-upgrade task is used to manually delete and regenerate the lock file.
                   # Otherwise, tests during the PR checks might fail.
-                  RENOVATE_ALLOWED_COMMANDS: '["echo >> Manually recreating Poetry lock file", "rm poetry.lock", "poetry lock"]'
+                  RENOVATE_ALLOWED_COMMANDS: '["echo [[Recreate Poetry lock file]]", "rm poetry.lock", "poetry lock"]'

--- a/.github/workflows/renovate-major.yml
+++ b/.github/workflows/renovate-major.yml
@@ -33,3 +33,9 @@ jobs:
                   RENOVATE_PACKAGE_RULES: >-
                       [{"matchUpdateTypes":["digest","minor","patch","pin","pinDigest","lockFileMaintenance"],"enabled":false}]
                   RENOVATE_REPOSITORIES: ${{ github.repository }}
+
+                  # 2026-04-12: Workaround for Poetry lock file not updated reliably. Inside the Renovate
+                  # config, a post-upgrade task is used to manually delete and regenerate the lock file.
+                  # Otherwise, tests during the PR checks might fail.
+                  RENOVATE_ALLOWED_COMMANDS: >-
+                      ["rm poetry.lock", "poetry lock"]

--- a/.github/workflows/renovate-major.yml
+++ b/.github/workflows/renovate-major.yml
@@ -30,12 +30,10 @@ jobs:
                   LOG_LEVEL: "info"
                   NPM_CONFIG_LEGACY_PEER_DEPS: "true"
                   RENOVATE_GIT_AUTHOR: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
-                  RENOVATE_PACKAGE_RULES: >-
-                      [{"matchUpdateTypes":["digest","minor","patch","pin","pinDigest","lockFileMaintenance"],"enabled":false}]
+                  RENOVATE_PACKAGE_RULES: '[{"matchUpdateTypes":["digest","minor","patch","pin","pinDigest","lockFileMaintenance"],"enabled":false}]'
                   RENOVATE_REPOSITORIES: ${{ github.repository }}
 
                   # 2026-04-12: Workaround for Poetry lock file not updated reliably. Inside the Renovate
                   # config, a post-upgrade task is used to manually delete and regenerate the lock file.
                   # Otherwise, tests during the PR checks might fail.
-                  RENOVATE_ALLOWED_COMMANDS: >-
-                      ["rm poetry.lock", "poetry lock"]
+                  RENOVATE_ALLOWED_COMMANDS: '["echo >> Manually recreating Poetry lock file", "rm poetry.lock", "poetry lock"]'

--- a/.github/workflows/renovate-minor.yml
+++ b/.github/workflows/renovate-minor.yml
@@ -36,4 +36,4 @@ jobs:
                   # 2026-04-12: Workaround for Poetry lock file not updated reliably. Inside the Renovate
                   # config, a post-upgrade task is used to manually delete and regenerate the lock file.
                   # Otherwise, tests during the PR checks might fail.
-                  RENOVATE_ALLOWED_COMMANDS: '["echo [[Recreate Poetry lock file]]", "rm poetry.lock", "poetry lock"]'
+                  RENOVATE_ALLOWED_COMMANDS: '["echo [[Recreate Poetry lock file]]", "rm -f poetry.lock", "poetry lock"]'

--- a/.github/workflows/renovate-minor.yml
+++ b/.github/workflows/renovate-minor.yml
@@ -33,3 +33,9 @@ jobs:
                   RENOVATE_PACKAGE_RULES: >-
                       [{"matchUpdateTypes":["major"],"enabled":false}]
                   RENOVATE_REPOSITORIES: ${{ github.repository }}
+
+                  # 2026-04-12: Workaround for Poetry lock file not updated reliably. Inside the Renovate
+                  # config, a post-upgrade task is used to manually delete and regenerate the lock file.
+                  # Otherwise, tests during the PR checks might fail.
+                  RENOVATE_ALLOWED_COMMANDS: >-
+                      ["rm poetry.lock", "poetry lock"]

--- a/.github/workflows/renovate-minor.yml
+++ b/.github/workflows/renovate-minor.yml
@@ -36,4 +36,4 @@ jobs:
                   # 2026-04-12: Workaround for Poetry lock file not updated reliably. Inside the Renovate
                   # config, a post-upgrade task is used to manually delete and regenerate the lock file.
                   # Otherwise, tests during the PR checks might fail.
-                  RENOVATE_ALLOWED_COMMANDS: '["echo >> Manually recreating Poetry lock file", "rm poetry.lock", "poetry lock"]'
+                  RENOVATE_ALLOWED_COMMANDS: '["echo [[Recreate Poetry lock file]]", "rm poetry.lock", "poetry lock"]'

--- a/.github/workflows/renovate-minor.yml
+++ b/.github/workflows/renovate-minor.yml
@@ -32,8 +32,3 @@ jobs:
                   RENOVATE_GIT_AUTHOR: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
                   RENOVATE_PACKAGE_RULES: '[{"matchUpdateTypes":["major"],"enabled":false}]'
                   RENOVATE_REPOSITORIES: ${{ github.repository }}
-
-                  # 2026-04-12: Workaround for Poetry lock file not updated reliably. Inside the Renovate
-                  # config, a post-upgrade task is used to manually delete and regenerate the lock file.
-                  # Otherwise, tests during the PR checks might fail.
-                  RENOVATE_ALLOWED_COMMANDS: '["echo [[Recreate Poetry lock file]]", "rm -f poetry.lock", "poetry lock"]'

--- a/.github/workflows/renovate-minor.yml
+++ b/.github/workflows/renovate-minor.yml
@@ -30,12 +30,10 @@ jobs:
                   LOG_LEVEL: "info"
                   NPM_CONFIG_LEGACY_PEER_DEPS: "true"
                   RENOVATE_GIT_AUTHOR: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
-                  RENOVATE_PACKAGE_RULES: >-
-                      [{"matchUpdateTypes":["major"],"enabled":false}]
+                  RENOVATE_PACKAGE_RULES: '[{"matchUpdateTypes":["major"],"enabled":false}]'
                   RENOVATE_REPOSITORIES: ${{ github.repository }}
 
                   # 2026-04-12: Workaround for Poetry lock file not updated reliably. Inside the Renovate
                   # config, a post-upgrade task is used to manually delete and regenerate the lock file.
                   # Otherwise, tests during the PR checks might fail.
-                  RENOVATE_ALLOWED_COMMANDS: >-
-                      ["rm poetry.lock", "poetry lock"]
+                  RENOVATE_ALLOWED_COMMANDS: '["echo >> Manually recreating Poetry lock file", "rm poetry.lock", "poetry lock"]'

--- a/poetry.lock
+++ b/poetry.lock
@@ -330,13 +330,13 @@ toml = ["tomli"]
 
 [[package]]
 name = "django"
-version = "6.0.3"
+version = "6.0"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 optional = false
 python-versions = ">=3.12"
 files = [
-    {file = "django-6.0.3-py3-none-any.whl", hash = "sha256:2e5974441491ddb34c3f13d5e7a9f97b07ba03bf70234c0a9c68b79bbb235bc3"},
-    {file = "django-6.0.3.tar.gz", hash = "sha256:90be765ee756af8a6cbd6693e56452404b5ad15294f4d5e40c0a55a0f4870fe1"},
+    {file = "django-6.0-py3-none-any.whl", hash = "sha256:1cc2c7344303bbfb7ba5070487c17f7fc0b7174bbb0a38cebf03c675f5f19b6d"},
+    {file = "django-6.0.tar.gz", hash = "sha256:7b0c1f50c0759bbe6331c6a39c89ae022a84672674aeda908784617ef47d8e26"},
 ]
 
 [package.dependencies]
@@ -902,4 +902,4 @@ zstd = ["backports-zstd (>=1.0.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.12,<4"
-content-hash = "fa202e8536f9c1748ad1f4beee9f315e2047ac6d8336a9a9388b4dca25595a06"
+content-hash = "24f4feb2870c307885e927ef6804e307ab203b1c4c08a74b994ff206215f8443"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4"
-django = ">=5.0,<=6.0.3"
+django = ">=5.0,<=6.0.0"
 djangorestframework = ">=3.14.0,<3.17.1"
 
 [tool.poetry.group.docs.dependencies]

--- a/renovate.json5
+++ b/renovate.json5
@@ -21,7 +21,7 @@
         "enabled": true,
         "automerge": true,
         "platformAutomerge": true,
-        "addLabels": "lockfile-update"
+        "addLabels": ["lockfile-update"]
     },
 
     // 2026-04-01: Workaround for Poetry lock files not reliably updated. Before committing the

--- a/renovate.json5
+++ b/renovate.json5
@@ -28,7 +28,7 @@
     // changes made by Renovate, we manually delete and regenerate the lock file. Note, that the
     // commands must be whitelisted in the CI workflows via env variables.
     "postUpgradeTasks": {
-        "commands": ["echo [[Recreate Poetry lock file]]", "rm poetry.lock", "poetry lock"],
+        "commands": ["echo [[Recreate Poetry lock file]]", "rm -f poetry.lock", "poetry lock"],
         "executionMode": "branch"
     },
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -20,14 +20,15 @@
     "lockFileMaintenance": {
         "enabled": true,
         "automerge": true,
-        "platformAutomerge": true
+        "platformAutomerge": true,
+        "addLabels": "lockfile-update"
     },
 
     // 2026-04-01: Workaround for Poetry lock files not reliably updated. Before committing the
     // changes made by Renovate, we manually delete and regenerate the lock file. Note, that the
     // commands must be whitelisted in the CI workflows via env variables.
     "postUpgradeTasks": {
-        "commands": ["rm poetry.lock", "poetry lock"],
+        "commands": ["echo >> Manually recreating Poetry lock file", "rm poetry.lock", "poetry lock"],
         "executionMode": "branch"
     },
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -20,8 +20,15 @@
     "lockFileMaintenance": {
         "enabled": true,
         "automerge": true,
-        "platformAutomerge": true,
-        "addLabels": ["minor-update"]
+        "platformAutomerge": true
+    },
+
+    // 2026-04-01: Workaround for Poetry lock files not reliably updated. Before committing the
+    // changes made by Renovate, we manually delete and regenerate the lock file. Note, that the
+    // commands must be whitelisted in the CI workflows via env variables.
+    "postUpgradeTasks": {
+        "commands": ["rm poetry.lock", "poetry lock"],
+        "executionMode": "branch"
     },
 
     // NOTE: Ordering matters. Later rules override earlier ones.

--- a/renovate.json5
+++ b/renovate.json5
@@ -28,7 +28,7 @@
     // changes made by Renovate, we manually delete and regenerate the lock file. Note, that the
     // commands must be whitelisted in the CI workflows via env variables.
     "postUpgradeTasks": {
-        "commands": ["echo >> Manually recreating Poetry lock file", "rm poetry.lock", "poetry lock"],
+        "commands": ["echo [[Recreate Poetry lock file]]", "rm poetry.lock", "poetry lock"],
         "executionMode": "branch"
     },
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -24,16 +24,22 @@
         "addLabels": ["lockfile-update"]
     },
 
-    // 2026-04-01: Workaround for Poetry lock files not reliably updated. Before committing the
-    // changes made by Renovate, we manually delete and regenerate the lock file. Note, that the
-    // commands must be whitelisted in the CI workflows via env variables.
-    "postUpgradeTasks": {
-        "commands": ["echo [[Recreate Poetry lock file]]", "rm -f poetry.lock", "poetry lock"],
-        "executionMode": "branch"
-    },
-
     // NOTE: Ordering matters. Later rules override earlier ones.
     "packageRules": [
+        {
+            // 2026-04-01: Workaround for Poetry lock files not reliably updated. Before committing the
+            // changes made by Renovate, we manually delete and regenerate the lock file. Note, that the
+            // commands must be whitelisted in the CI workflows via env variables.
+            //
+            // This is a bit redundant to recreating the lockfile anyway during CI environment setup.
+            // But this way an up to date lockfile gets committed, too.
+            "description": "Post upgrade task: Recreate poetry lock file",
+            "matchManagers": ["poetry"],
+            "postUpgradeTasks": {
+                "commands": ["echo [[Recreate Poetry lock file]]", "rm -f poetry.lock", "poetry lock"],
+                "executionMode": "branch"
+            }
+        },
         {
             // NOTE: For applications "bump" is a good choice, to use the most recent versions.
             // For reusable libraries "widen" combined with testing against different versions

--- a/renovate.json5
+++ b/renovate.json5
@@ -14,8 +14,8 @@
     "enabledManagers": ["github-actions", "poetry"],
     "labels": ["dependencies", "automated"],
     "configMigration": true,
-    "prConcurrentLimit": 10,
-    "prHourlyLimit": 2,
+    //"prConcurrentLimit": 10,
+    //"prHourlyLimit": 2,
     "rebaseWhen": "behind-base-branch",
     "lockFileMaintenance": {
         "enabled": true,
@@ -26,20 +26,6 @@
 
     // NOTE: Ordering matters. Later rules override earlier ones.
     "packageRules": [
-        {
-            // 2026-04-01: Workaround for Poetry lock files not reliably updated. Before committing the
-            // changes made by Renovate, we manually delete and regenerate the lock file. Note, that the
-            // commands must be whitelisted in the CI workflows via env variables.
-            //
-            // This is a bit redundant to recreating the lockfile anyway during CI environment setup.
-            // But this way an up to date lockfile gets committed, too.
-            "description": "Post upgrade task: Recreate poetry lock file",
-            "matchManagers": ["poetry"],
-            "postUpgradeTasks": {
-                "commands": ["echo [[Recreate Poetry lock file]]", "rm -f poetry.lock", "poetry lock"],
-                "executionMode": "branch"
-            }
-        },
         {
             // NOTE: For applications "bump" is a good choice, to use the most recent versions.
             // For reusable libraries "widen" combined with testing against different versions


### PR DESCRIPTION
Remove workaround for Renovate to delete and recreate the lock file, as it didn't work anyway (the whitelisting via env variables in the GH actions workflows didn't work) and the underlying issue is probably more that the Poetry versions differ in CI and locally.